### PR TITLE
Add Xenition to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [VisaCanvas](https://visacanvas.com/) - Free AI-powered EB1A/NIW immigration eligibility assessment with 10-criteria analysis
 - [Notah.ai](https://notah.ai) - AI-powered meeting notes, transcription, and action items, an AI Executive Assistant.
 - [Puppyone](https://www.puppyone.ai) - Free cloud file system built for AI agents. Native MCP, file-level security, version history, 15+ OAuth connectors (Notion/GitHub/Drive/Linear). No credit card required. Open source (Apache 2.0) with Docker self-host option.
+- [Xenition](https://xenition.com) - One AI workspace covering 23 editing surfaces - documents, spreadsheets, slides, design, code and research - all driven from a single chat, with shared memory and a common asset library between them. Free tier gives 25,000 credits every month, no credit card required.
 
 
 ## Prompt 


### PR DESCRIPTION
Adds [Xenition](https://xenition.com) to the **AI** section. One line added, nothing else touched.

### Why it belongs on a free-SaaS list

The free tier is a real working tier, not a trial: **25,000 credits every month, no credit card**, renewed monthly rather than expiring after a countdown. Paid plans only raise limits and add priority access to newer models.

### What it is

One AI workspace spanning 23 editing surfaces — documents, spreadsheets, slides, design, code and research — all driven from a single chat. The surfaces share one memory and one asset library, so output from one flows into another instead of being exported and re-uploaded between separate tools.

### Placement and format

- Appended to the end of **AI**, matching how the most recent merged additions (Puppyone, Notah.ai, VisaCanvas) were placed — this section is in insertion order, not alphabetical.
- Follows the existing item format: `- [Name](link) - Description`.
- Link is live over HTTPS, and Xenition does not already appear anywhere in the list.

Thanks for maintaining the list.